### PR TITLE
Patch DiscordExperiments for recent Discord update

### DIFF
--- a/plugins/discordexperiments.plugin.js
+++ b/plugins/discordexperiments.plugin.js
@@ -26,12 +26,6 @@ module.exports = class {
 	}
 
 	stop(){
-		try {
-		    Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes).find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({user: {flags: 0}, type: "CONNECTION_OPEN"})
-		} catch (e) {
-			if (e.message != "Cannot read property 'hasLoadedExperiments' of undefined") {
-				throw e;
-			}
-		}
+		Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes).find(x => x.name == "ExperimentStore").actionHandler["LOGOUT"]()
 	}
 };

--- a/plugins/discordexperiments.plugin.js
+++ b/plugins/discordexperiments.plugin.js
@@ -17,7 +17,14 @@ module.exports = class {
 	start() {
 		const nodes = Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes);
 		try {
-			nodes.find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({user: {flags: 1}, type: "CONNECTION_OPEN"})
+			nodes.find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({
+				user: {flags: 1},
+				type: "CONNECTION_OPEN",
+				serializedExperimentStore: {
+					hasLoadedExperiments: true,
+					get trackedExposureExperiments() {throw true;}
+				}
+			})
 		} catch (e) {} // this will always intentionally throw
 		const oldGetUser = userStore.__proto__.getCurrentUser;
 		userStore.__proto__.getCurrentUser = () => ({hasFlag: () => true})
@@ -26,6 +33,14 @@ module.exports = class {
 	}
 
 	stop(){
-		Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes).find(x => x.name == "ExperimentStore").actionHandler["LOGOUT"]()
+		try {
+			Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes).find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({
+				user: {flags: 0},
+				serializedExperimentStore: {
+					hasLoadedExperiments: false,
+					get trackedExposureExperiments() {throw true;}
+				}
+			})
+		} catch (e) {} // this will also intentionally throw
 	}
 };

--- a/plugins/discordexperiments.plugin.js
+++ b/plugins/discordexperiments.plugin.js
@@ -8,24 +8,30 @@
  * @updateUrl https://betterdiscord.app/gh-redirect?id=206
  */
 
-const settingsStore = BdApi.findModule(m => typeof m?.default?.isDeveloper !== "undefined");
-const userStore = BdApi.findModule(m => m?.default?.getUsers);
+const settingsStore = BdApi.findModule(m => typeof m?.isDeveloper !== "undefined");
+const userStore = BdApi.findModule(m => m?.getUsers && m?._version == undefined);
 
 module.exports = class {
 	getName(){ return "Discord Experiments"; }
 
 	start() {
-		const nodes = Object.values(settingsStore.default._dispatcher._dependencyGraph.nodes);
+		const nodes = Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes);
 		try {
 			nodes.find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({user: {flags: 1}, type: "CONNECTION_OPEN"})
 		} catch (e) {} // this will always intentionally throw
-		const oldGetUser = userStore.default.__proto__.getCurrentUser;
-		userStore.default.__proto__.getCurrentUser = () => ({hasFlag: () => true})
+		const oldGetUser = userStore.__proto__.getCurrentUser;
+		userStore.__proto__.getCurrentUser = () => ({hasFlag: () => true})
 		nodes.find(x => x.name == "DeveloperExperimentStore").actionHandler["OVERLAY_INITIALIZE"]()
-		userStore.default.__proto__.getCurrentUser = oldGetUser
+		userStore.__proto__.getCurrentUser = oldGetUser
 	}
 
 	stop(){
-		Object.values(settingsStore.default._dispatcher._dependencyGraph.nodes).find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({user: {flags: 0}, type: "CONNECTION_OPEN"})
+		try {
+		    Object.values(settingsStore._dispatcher._actionHandlers._dependencyGraph.nodes).find(x => x.name == "ExperimentStore").actionHandler["OVERLAY_INITIALIZE"]({user: {flags: 0}, type: "CONNECTION_OPEN"})
+		} catch (e) {
+			if (e.message != "Cannot read property 'hasLoadedExperiments' of undefined") {
+				throw e;
+			}
+		}
 	}
 };


### PR DESCRIPTION
Based on the comments of [this gist](https://gist.github.com/MeguminSama/2cae24c9e4c335c661fa94e72235d4c4).

The userStore that needs to be patched seems to have moved to a new module. The old module still exists and has similar properties, but it has a property called _version that the new module does not.

I found that `{flags: 0}` no longer disabled experiments, so I instead defined part of the missing object that causes an exception on line 20. To prevent other experiment variables from being clobbered, the object passed to the action handler has a getter that intentionally throws an error.

Tested on Stable 149549 (1e1ae6d).